### PR TITLE
Fix support on python 3

### DIFF
--- a/molecule/settings.py
+++ b/molecule/settings.py
@@ -180,7 +180,7 @@ class SpecPreprocessor(object):
             # call recursively
             new_split_line.append(new_arg)
 
-        new_line = " ".join(new_split_line) + "\n"
+        new_line = " ".join(map(bytes.decode, new_split_line)) + "\n"
         return self._builtin_recursive_expand(new_line)
 
     def parse(self):


### PR DESCRIPTION
Traceback (most recent call last):
    File "/usr/bin/molecule", line 29, in <module>
        parse_data = molecule.cmdline.parse()
      File "/usr/lib/molecule/molecule/cmdline.py", line 61, in parse
        obj = SpecParser(el)
      File "/usr/lib/molecule/molecule/settings.py", line 218, in
    __init__
        execution_strategy = self.parse_execution_strategy()
      File "/usr/lib/molecule/molecule/settings.py", line 230, in
    parse_execution_strategy
        data = self._generic_parser()
      File "/usr/lib/molecule/molecule/settings.py", line 300, in
    _generic_parser
        content = self._preprocessor.parse()
      File "/usr/lib/molecule/molecule/settings.py", line 191, in parse
        line = self._builtin_recursive_expand(line)
      File "/usr/lib/molecule/molecule/settings.py", line 131, in
    _builtin_recursive_expand
        line = expander(line)
      File "/usr/lib/molecule/molecule/settings.py", line 183, in
    _env_expander
        new_line = " ".join(new_split_line) + "\n"
    TypeError: sequence item 0: expected str instance, bytes found